### PR TITLE
feat: added api dns association

### DIFF
--- a/lib/schema.graphql
+++ b/lib/schema.graphql
@@ -5,3 +5,74 @@ type Query {
 type Schema {
   query: Query
 }
+
+type Category{
+    id: ID!
+    name: String!
+    description: String
+    active: Boolean
+}
+
+type Exercise{
+    id:ID!
+    name: String!
+    description: String
+    active: Boolean
+    links: [Link!]
+    category: Category
+}
+
+type Link{
+    id:ID!
+    name: String!
+    url: String
+    active: Boolean
+    type: LinkType
+}
+
+enum LinkType{
+    VIDEO
+    PHOTO
+    WEBSITE
+}
+
+type Plan {
+    id:ID!
+    user_id: String!
+    active: Boolean
+    weeks: [Week!]
+    notes: [Note!]
+}
+
+type Week{
+    id:ID!
+    plan: Plan
+    number: Int!
+    date: AWSDateTime
+    workout: [Workout]
+    notes: [Note!]
+}
+
+type Workout{
+    id:ID!
+    exercise: Exercise
+    sets: [Set!]
+    notes: [Note!]
+}
+
+type Set{
+    id:ID!
+    number: Int
+    reps: Int
+    weight: Int
+    totat: Int
+}
+
+type Note{
+    id:ID!
+    user_id: String
+    note: String
+    date: AWSDateTime
+}
+
+scalar AWSDateTime

--- a/lib/workout-planner-aws-iac-stack.ts
+++ b/lib/workout-planner-aws-iac-stack.ts
@@ -3,14 +3,33 @@ import { Construct } from 'constructs';
 import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as path from 'path';
 
+const APPSYNC_CERT_ARN = 'arn:aws:acm:us-east-1:825765426384:certificate/06c7226c-d932-4771-85ec-cfcc09f38b51';
+
+
 export class WorkoutPlannerAppSyncStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    // Get Certificate
+    const certificate = cdk.aws_certificatemanager.Certificate.fromCertificateArn(
+      this,
+      "luna-gsd-cert",
+      APPSYNC_CERT_ARN,
+    );
+
+    const appsyncDomainName = new appsync.CfnDomainName(
+      this,
+      'LunaGSDDomainName',
+      {
+        certificateArn: certificate.certificateArn,
+        domainName: "api.luna-gsd.com",
+      }
+    );
+
     // Create the AppSync API
     const api = new appsync.GraphqlApi(this, 'WorkoutPlannerAppSyncAPI', {
       name: 'workout-planner-api',
-      schema: appsync.SchemaFile.fromAsset(path.join(__dirname, 'schema.graphql')),
+      definition: appsync.Definition.fromFile(path.join(__dirname, 'schema.graphql')),
       authorizationConfig: {
         defaultAuthorization: {
           authorizationType: appsync.AuthorizationType.API_KEY,
@@ -20,6 +39,18 @@ export class WorkoutPlannerAppSyncStack extends cdk.Stack {
         },
       },
     });
+
+    const assoc = new appsync.CfnDomainNameApiAssociation(
+      this,
+      'WorkoutPlannerAppSyncAPIAssociation',
+      {
+        apiId: api.apiId,
+        domainName: "api.luna-gsd.com",
+      }
+    );
+    
+    //  Required to ensure the resources are created in order
+    assoc.addDependency(appsyncDomainName);
 
     // Output the GraphQL API URL and API Key
     new cdk.CfnOutput(this, 'GraphQLAPIURL', {


### PR DESCRIPTION
Add initial graphql schema and cdk steps to setup appsync and associate api to dns.